### PR TITLE
Use a ~16:9 resolution by default

### DIFF
--- a/data/maps/Limestone Island/cape_ruins.lua
+++ b/data/maps/Limestone Island/cape_ruins.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
 
   -- You can initialize the movement and sprites of various
   -- map entities here.

--- a/data/maps/Limestone Island/caves/sanctuary_1.lua
+++ b/data/maps/Limestone Island/caves/sanctuary_1.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
 
   -- You can initialize the movement and sprites of various
   -- map entities here.

--- a/data/maps/Limestone Island/caves/sanctuary_2.lua
+++ b/data/maps/Limestone Island/caves/sanctuary_2.lua
@@ -12,7 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
-
+  self:get_camera():letterbox()
   -- You can initialize the movement and sprites of various
   -- map entities here.
 end

--- a/data/maps/Yarrowmouth/caves/dandelion_charm_cave.lua
+++ b/data/maps/Yarrowmouth/caves/dandelion_charm_cave.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
 
   if game:get_value("have_dandelion_charm") == true and game:get_value("dandelion_charm_obtained") == nil then
       map:create_pickable({

--- a/data/maps/Yarrowmouth/caves/ghost_ship.lua
+++ b/data/maps/Yarrowmouth/caves/ghost_ship.lua
@@ -10,7 +10,9 @@
 local map = ...
 local game = map:get_game()
 
-
+function map:on_started()
+  self:get_camera():letterbox()
+end
 
 function boss_sensor:on_activated()
   boss_sensor:set_enabled(false)

--- a/data/maps/Yarrowmouth/hourglass_fort/basement.lua
+++ b/data/maps/Yarrowmouth/hourglass_fort/basement.lua
@@ -17,6 +17,8 @@ local crab_spawn_timer
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
+
   in_boss_battle = false
   map:open_doors("boss_door_enter")
 

--- a/data/maps/Yarrowmouth/hourglass_fort/tunnel.lua
+++ b/data/maps/Yarrowmouth/hourglass_fort/tunnel.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
 
   -- You can initialize the movement and sprites of various
   -- map entities here.

--- a/data/maps/Yarrowmouth/interiors/lighthouse.lua
+++ b/data/maps/Yarrowmouth/interiors/lighthouse.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
 
   -- You can initialize the movement and sprites of various
   -- map entities here.

--- a/data/maps/Yarrowmouth/interiors/silent_glade_health.lua
+++ b/data/maps/Yarrowmouth/interiors/silent_glade_health.lua
@@ -9,3 +9,7 @@
 
 local map = ...
 local game = map:get_game()
+
+function map:on_started()
+  self:get_camera():letterbox()
+end

--- a/data/maps/ballast_harbor/council_building.lua
+++ b/data/maps/ballast_harbor/council_building.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 map:register_event("on_started", function()
+  self:get_camera():letterbox()
   charging_pirate:set_enabled(false)
   return_sensor:set_enabled(false)
   if game:get_value("ballast_charging_pirate_defeated") == true then

--- a/data/maps/ballast_harbor/tavern.lua
+++ b/data/maps/ballast_harbor/tavern.lua
@@ -12,7 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
-
+  self:get_camera():letterbox()
   -- You can initialize the movement and sprites of various
   -- map entities here.
 end

--- a/data/maps/goatshead_island/caves/goat_caverns.lua
+++ b/data/maps/goatshead_island/caves/goat_caverns.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+    self:get_camera():letterbox()
     key_chest:set_enabled(false)
   if game:get_value("goat_caverns_key_spider") ~= nil then
     key_chest:set_enabled(true)

--- a/data/maps/goatshead_island/interiors/brute_hq.lua
+++ b/data/maps/goatshead_island/interiors/brute_hq.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
 --initialize NPCs
 --entry guard
   if game:get_value("barbell_brutes_defeated") == true then entry_guard:set_enabled(false) else entry_guard_2:set_enabled(false) end

--- a/data/maps/goatshead_island/interiors/inn.lua
+++ b/data/maps/goatshead_island/interiors/inn.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
   go_to_bed:set_enabled(false)
 
 end

--- a/data/maps/goatshead_island/interiors/merchant_hq.lua
+++ b/data/maps/goatshead_island/interiors/merchant_hq.lua
@@ -13,6 +13,7 @@ local guard_run
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+   self:get_camera():letterbox()
 --enable entities
    if game:get_value("mhq_thomas_left") == true then thomas:set_enabled(false) end
    if game:get_value("phantom_squid_quest_completed") ~= true then merchant_hopeful:set_enabled(false) end

--- a/data/maps/goatshead_island/interiors/rilesdorf_mercantile.lua
+++ b/data/maps/goatshead_island/interiors/rilesdorf_mercantile.lua
@@ -15,6 +15,7 @@ local hero = game:get_hero()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
 --enable entities
   if game:get_value("squid_fled") ~= true then
     rilesdorf_2:set_enabled(false)

--- a/data/maps/goatshead_island/interiors/tunnels.lua
+++ b/data/maps/goatshead_island/interiors/tunnels.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
   --initialize adventurers if quest accepted
   if game:get_value("goatshead_tunnels_accepted") ~= true then
     adventurer_1:set_enabled(false)

--- a/data/maps/goatshead_island/spruce_head_shrine.lua
+++ b/data/maps/goatshead_island/spruce_head_shrine.lua
@@ -13,6 +13,7 @@ local hero = map:get_hero()
 
 
 map:register_event("on_started", function()
+  self:get_camera():letterbox()
   ilex_2:set_enabled(false)
   statue_treasure_chest:set_enabled(false)
   if game:get_value("spruce_head_arborgeist_defeated") == true then

--- a/data/maps/oakhaven/caves/manna_oak_tunnels.lua
+++ b/data/maps/oakhaven/caves/manna_oak_tunnels.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
   if game:get_value("spoken_with_hazel_in_manna_oak_tunnels") then
     gonna_die_blob:set_enabled(false)
   end

--- a/data/maps/oakhaven/fort_crow/basement.lua
+++ b/data/maps/oakhaven/fort_crow/basement.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
   --steams A start enabled, steams B start disabled
   crow_enemy:set_enabled(false)
   if game:get_value("fort_crow_entry_bridge_activated") == true then bridge:set_enabled(true) end

--- a/data/maps/oakhaven/fort_crow/courtyard.lua
+++ b/data/maps/oakhaven/fort_crow/courtyard.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
 
   if game:get_value("quest_pirate_fort") == 4 then game:set_value("quest_pirate_fort", 5) end
   if game:get_value("fort_crow_furnace_lit") == true then tower_door:set_enabled(false) end

--- a/data/maps/oakhaven/fort_crow/furnace_area.lua
+++ b/data/maps/oakhaven/fort_crow/furnace_area.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
   al_jazari:set_enabled(false)
   for entity in map:get_entities("switchsteam_b") do entity:set_enabled(false) end
   if game:get_value("fort_crow_furnace_door_a") == true then map:set_doors_open("door_a") end

--- a/data/maps/oakhaven/fort_crow/tower.lua
+++ b/data/maps/oakhaven/fort_crow/tower.lua
@@ -13,6 +13,7 @@ local hero = game:get_hero()
 
 
 function map:on_started()
+  self:get_camera():letterbox()
   if game:has_item("hideout_chart") == true then
   hideout_chart:set_enabled(false)
   end

--- a/data/maps/oakhaven/interiors/cave_house.lua
+++ b/data/maps/oakhaven/interiors/cave_house.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
 
   -- You can initialize the movement and sprites of various
   -- map entities here.

--- a/data/maps/oakhaven/interiors/hornwart_inn.lua
+++ b/data/maps/oakhaven/interiors/hornwart_inn.lua
@@ -13,6 +13,7 @@ local hero = map:get_hero()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
   if game:get_value("hornwart_know_hazel") ~= nil then map:open_doors("hazel_door") end
   if game:get_value("quest_manna_oaks") then hazel:set_enabled(false) end
   if game:get_value("found_hazel") ~= true then

--- a/data/maps/oakhaven/interiors/library.lua
+++ b/data/maps/oakhaven/interiors/library.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
   if game:get_value("visited_hazel_room") == true then
     for entity in map:get_entities("block_book") do entity:set_enabled(false) end
   end

--- a/data/maps/oakhaven/interiors/library2.lua
+++ b/data/maps/oakhaven/interiors/library2.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
 
   -- You can initialize the movement and sprites of various
   -- map entities here.

--- a/data/maps/oakhaven/interiors/monastery.lua
+++ b/data/maps/oakhaven/interiors/monastery.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
 
   -- You can initialize the movement and sprites of various
   -- map entities here.

--- a/data/maps/oakhaven/interiors/palace.lua
+++ b/data/maps/oakhaven/interiors/palace.lua
@@ -13,6 +13,7 @@ local hero = map:get_hero()
 
 
 function map:on_started()
+  self:get_camera():letterbox()
   guard_2:set_enabled(false)
   guard_3:set_enabled(false)
   enemy_guard:set_enabled(false)

--- a/data/maps/oakhaven/interiors/saloon.lua
+++ b/data/maps/oakhaven/interiors/saloon.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
   if game:get_value("salamander_heartache_storehouse_door_open") == true then map:open_doors("storehouse_door") end
   if game:has_item("sleeping_draught") == true then star_barrel:set_enabled(true) end
   if game:get_value("morus_available") ~= true then morus:set_enabled(false) end

--- a/data/maps/oakhaven/interiors/tailor.lua
+++ b/data/maps/oakhaven/interiors/tailor.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 function map:on_started()
+  self:get_camera():letterbox()
 
   -- You can initialize the movement and sprites of various
   -- map entities here.

--- a/data/maps/oakhaven/veilwood.lua
+++ b/data/maps/oakhaven/veilwood.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 map:register_event("on_started", function()
+  self:get_camera():letterbox()
   if game:get_value("quest_manna_oaks") == 0 then manna_oak_twig:set_enabled(true) end
   if game:get_value("amalenchier_tomb_open") then
     amalenchier_tombstone:set_enabled(false)

--- a/data/maps/snapmast_reef/snapmast_landing.lua
+++ b/data/maps/snapmast_reef/snapmast_landing.lua
@@ -12,6 +12,7 @@ local game = map:get_game()
 
 -- Event called at initialization time, as soon as this map becomes is loaded.
 map:register_event("on_started", function()
+  self:get_camera():letterbox()
   local world = map:get_world()
   game:set_world_rain_mode(world, "storm")
   if game:get_value("quest_snapmast") == 0 then game:set_value("quest_snapmast", 1) end

--- a/data/quest.dat
+++ b/data/quest.dat
@@ -9,8 +9,8 @@ quest{
   quest_version = "",
   release_date = "",
   website = "maxmraz.github.io/oceans-heart-website",
-  normal_quest_size = "320x240",
-  min_quest_size = "320x240",
-  max_quest_size = "320x240",
+  normal_quest_size = "416x240",
+  min_quest_size = "416x240",
+  max_quest_size = "416x240",
 }
 

--- a/data/scripts/hud/hud_config.lua
+++ b/data/scripts/hud/hud_config.lua
@@ -15,21 +15,21 @@ local hud_config = {
   -- Hearts meter.
   {
     menu_script = "scripts/hud/hearts",
-    x = 10,
+    x = 58,
     y = -250,
   },
-  
+
     --magic meter
     {
       menu_script = "scripts/hud/magic_bar",
-      x = 10,
+      x = 58,
       y = 1,
     },
-  
+
   -- Rupee counter.
   {
     menu_script = "scripts/hud/rupees",
-    x = 285,
+    x = 333,
     y = 220,
   },
 -- ]]
@@ -39,14 +39,14 @@ local hud_config = {
   --[[
 {
     menu_script = "scripts/hud/bombs",
-    x = 235,
+    x = 283,
     y = 220,
   },
 
   -- Arrows counter.
 {
     menu_script = "scripts/hud/arrows",
-    x = 260,
+    x = 308,
     y = 220,
   },
 --]]
@@ -54,17 +54,17 @@ local hud_config = {
   -- Item assigned to slot 1.
   {
     menu_script = "scripts/hud/item",
-    x = 266,
+    x = 314,
     y = 1,
     slot = 1,  -- Item slot (1 or 2).
   },
- 
+
 
 
  -- Item assigned to slot 2.
   {
     menu_script = "scripts/hud/item",
-    x = 290,
+    x = 338,
     y = 8,
     slot = 2,  -- Item slot (1 or 2).
   },

--- a/data/scripts/meta/camera.lua
+++ b/data/scripts/meta/camera.lua
@@ -56,4 +56,11 @@ function camera_meta:shake(config, callback)
   shake_step()
 end
 
+-- Set the camera to a 4:3 aspect ratio for this map.
+-- Useful as a fallback for old maps that need this.
+function camera_meta:letterbox()
+  self:set_size(320, 240)
+  self:set_position_on_screen(48, 0)
+end
+
 return true


### PR DESCRIPTION
Video demo: https://matrix.org/_matrix/media/v1/download/matrix.org/FbYSHOjbeKAjplZZntkowvzd

I chose 416x240 as the new default resolution for maps. A true 16:9 would be 426.66..x240 ([full list of 16:9 resolutions](https://pacoup.com/2011/06/12/list-of-true-169-resolutions/)), but I chose this resolution because:

1. It still fills up most of the screen.
2. Length and width are divisible by 16. It's 26 tiles across and 15 tiles high.
3. It doesn't change the height of your quest, so it still looks the same - just wider.
4. It's not *smaller* than your quest size. You can't use `camera:set_size()` to enlarge your quest, but you can use it to letterbox your quest. Therefore, you won't have to redo any dungeons. You can just letterbox them.

I've added a convenience function, `camera:letterbox()`. You should call this on the `map:on_started()` event of every map that needs it (most maps don't). I've done so in hourglass_fort/basement.lua as an example, but you know your game better than me so you can add this function call to those maps.

Finally, I nudged the HUD over so it's centered. It's as simple as adding 48px to the x-position of any drawable.