### PR TITLE
Localize Menu Strings

### DIFF
--- a/data/languages/en/text/dialogs.dat
+++ b/data/languages/en/text/dialogs.dat
@@ -15434,6 +15434,16 @@ Blacksmith and Armorer
 }
 
 dialog{
+  id = "credits",
+  text = [[
+Created By:Max Mraz
+Additional Programming:Llamazing
+Special Thanks to:Alex Gleason
+The End
+]],
+}
+
+dialog{
   id = "demo_1.npcs.arrow_guy.1",
   text = [[
 Look, I'll help you out this time but if you

--- a/data/languages/en/text/strings.dat
+++ b/data/languages/en/text/strings.dat
@@ -120,4 +120,5 @@ text{ key = "menu.quest_log.quest_log_update", value = "Quest Log Updated!" }
 text{ key = "menu.quest_log.quests_count", value = "$v1 of $v2 complete" }
 text{ key = "menu.quest_log.side_quests_tab", value = "Side\nQuests" }
 text{ key = "menu.quest_log.title", value = "Quest Log" }
+text{ key = "menu.quest_update.quest_updated", value = "Quest Log Updated!" }
 text{ key = "player_name", value = "Tilia" }

--- a/data/languages/en/text/strings.dat
+++ b/data/languages/en/text/strings.dat
@@ -1,78 +1,86 @@
 text{ key = "action.back", value = "Back" }
-text{ key = "menu.title.continue", value = "Continue" }
-text{ key = "menu.title.new_game", value = "New Game" }
-text{ key = "menu.title.quit", value = "Quit" }
-text{ key = "menu.title.confirm", value = "Confirm" }
-text{ key = "menu.title.cancel", value = "Cancel" }
-text{ key = "item.elixer.1", value = "Elixer Vitae" }
-text{ key = "item.potion_magic_restoration.1", value = "Potion of Magic Restoration"}
-text{ key = "item.potion_stoneskin.1", value = "Stoneskin Potion"}
-text{ key = "item.potion_burlyblade.1", value = "Burlyblade Potion"}
-text{ key = "item.potion_fleetseed.1", value = "Fleetseed Potion"}
-text{ key = "item.ether_bombs.1", value = "Ether Bombs"}
-text{ key = "item.iron_candle.1", value = "Salt Candles"}
-text{ key = "item.homing_eye.1", value = "Seeker Eyes"}
-text{ key = "item.bow.1", value = "Bow" }
-text{ key = "item.bombs_counter_2.1", value = "Bombs" }
-text{ key = "item.barrier.1", value = "Devana's Barrier" }
+text{ key = "item.apples.1", value = "Apples" }
+text{ key = "item.armor_tools.1", value = "Armorer's Tool Set" }
+text{ key = "item.aster_note.1", value = "Threatening Note" }
 text{ key = "item.ball_and_chain.1", value = "Flail" }
+text{ key = "item.barrier.1", value = "Devana's Barrier" }
+text{ key = "item.berries.1", value = "Berries" }
+text{ key = "item.bomb_arrow_ticket.1", value = "Bomb Shop Ticket" }
+text{ key = "item.bombs_counter_2.1", value = "Bombs" }
 text{ key = "item.boomerang.1", value = "Boomerang" }
-text{ key = "item.spear.1", value = "Bear Warriors' Spear" }
-text{ key = "item.bow_warp.1", value = "Warpbolt Charm" }
+text{ key = "item.bow.1", value = "Bow" }
 text{ key = "item.bow_bombs.1", value = "Bomb Arrows" }
 text{ key = "item.bow_fire.1", value = "Flame Arrows" }
-text{ key = "item.berries.1", value = "Berries" }
-text{ key = "item.apples.1", value = "Apples" }
+text{ key = "item.bow_warp.1", value = "Warpbolt Charm" }
 text{ key = "item.bread.1", value = "Burroak Bread" }
-text{ key = "item.thunder_charm.1", value = "Seabird's Tear" }
-text{ key = "item.leaf_tornado.1", value = "Amalenchier's Wrath" }
-text{ key = "item.gust.1", value = "Zephyrine's Tempest" }
-text{ key = "item.crystal_spark.1", value = "Ophira's Ember" }
-text{ key = "item.cyclone_charm.1", value = "Cyclone Charm" }
-text{ key = "item.coral_ore.1", value = "Coral Ore" }
 text{ key = "item.burdock.1", value = "Burdock Roots" }
 text{ key = "item.chamomile.1", value = "Chamomile Flowers" }
+text{ key = "item.charts.1", value = "Klepton's Charts" }
+text{ key = "item.contract.1", value = "Exploitative Contract" }
+text{ key = "item.coral_ore.1", value = "Coral Ore" }
+text{ key = "item.crystal_spark.1", value = "Ophira's Ember" }
+text{ key = "item.cyclone_charm.1", value = "Cyclone Charm" }
+text{ key = "item.elixer.1", value = "Elixer Vitae" }
+text{ key = "item.ether_bombs.1", value = "Ether Bombs" }
 text{ key = "item.firethorn_berries.1", value = "Firethorn Berries" }
+text{ key = "item.geode.1", value = "Monsterous Geodes" }
 text{ key = "item.ghost_orchid.1", value = "Ghost Orchids" }
+text{ key = "item.gust.1", value = "Zephyrine's Tempest" }
+text{ key = "item.hideout_chart.1", value = "Pirate Council Hideout Chart" }
+text{ key = "item.homing_eye.1", value = "Seeker Eyes" }
+text{ key = "item.honeycomb.1", value = "Hornet Honeycomb" }
+text{ key = "item.iron_candle.1", value = "Salt Candles" }
+text{ key = "item.iron_pinecone.1", value = "Iron Pinecone" }
+text{ key = "item.key_juneberry_inn.1", value = "Key to Another Inn?" }
+text{ key = "item.key_juniper_grove.1", value = "Juniper Grove Entrance Key" }
+text{ key = "item.key_juniper_grove_2.1", value = "Juniper Grove Inner Gate Key" }
+text{ key = "item.key_kingsdown.1", value = "Mallow's Key" }
+text{ key = "item.key_mead_safehouse.1", value = "Sticky Honey Key" }
+text{ key = "item.key_mushroom_spot.1", value = "Key to Mushroom Picking Spot" }
+text{ key = "item.key_poplar_shack.1", value = "Mossy Poplar Forest Key" }
+text{ key = "item.key_sinking_lighthouse.1", value = "Seaglint Ruins Key" }
+text{ key = "item.key_thrush_fort.1", value = "Thrush Fort Key" }
 text{ key = "item.kingscrown.1", value = "Kingscrown Blooms" }
 text{ key = "item.lavendar.1", value = "Lavendar Flowers" }
-text{ key = "item.witch_hazel.1", value = "Witch Hazel Flowers" }
-text{ key = "item.mandrake_white.1", value = "White Mandrake Roots" }
+text{ key = "item.leaf_tornado.1", value = "Amalenchier's Wrath" }
 text{ key = "item.mandrake.1", value = "Mandrake Root" }
-text{ key = "item.geode.1", value = "Monsterous Geodes" }
+text{ key = "item.mandrake_white.1", value = "White Mandrake Roots" }
+text{ key = "item.manna_oak_letter.1", value = "Manna Oak Letter" }
+text{ key = "item.manna_oak_twig.1", value = "Manna Oak Twig" }
+text{ key = "item.monkshood.1", value = "Monkshood Petals" }
 text{ key = "item.monster_bones.1", value = "Monster Bones" }
 text{ key = "item.monster_eye.1", value = "Monster Eye" }
 text{ key = "item.monster_guts.1", value = "Eyes of Monstrosity" }
 text{ key = "item.monster_heart.1", value = "Abyssal Hearts" }
-text{ key = "item.whisky_for_juglan.1", value = "Whisky" }
-text{ key = "item.iron_pinecone.1", value = "Iron Pinecone" }
-text{ key = "item.aster_note.1", value = "Threatening Note" }
-text{ key = "item.contract.1", value = "Exploitative Contract" }
-text{ key = "item.oranges_shipment.1", value = "Box of Oranges" }
-text{ key = "item.prize_money.1", value = "Prize Money (200 Crowns)" }
-text{ key = "item.key_thrush_fort.1", value = "Thrush Fort Key" }
-text{ key = "item.charts.1", value = "Klepton's Charts" }
-text{ key = "item.key_kingsdown.1", value = "Mallow's Key" }
-text{ key = "item.key_juniper_grove.1", value = "Juniper Grove Entrance Key" }
-text{ key = "item.key_juniper_grove_2.1", value = "Juniper Grove Inner Gate Key" }
-text{ key = "item.key_mushroom_spot.1", value = "Key to Mushroom Picking Spot" }
-text{ key = "item.key_mead_safehouse.1", value = "Sticky Honey Key" }
-text{ key = "item.key_juneberry_inn.1", value = "Key to Another Inn?" }
-text{ key = "item.key_poplar_shack.1", value = "Mossy Poplar Forest Key" }
-text{ key = "item.key_sinking_lighthouse.1", value = "Seaglint Ruins Key" }
-text{ key = "item.stone_beak.1", value = "A Beak-shaped Stone?" }
-text{ key = "item.sleeping_draught.1", value = "Sleeping Draught" }
-text{ key = "item.hideout_chart.1", value = "Pirate Council Hideout Chart" }
-text{ key = "item.monkshood.1", value = "Monkshood Petals" }
-text{ key = "item.honeycomb.1", value = "Hornet Honeycomb" }
-text{ key = "item.bomb_arrow_ticket.1", value = "Bomb Shop Ticket" }
-text{ key = "item.bow_bombs.1", value = "Bomb Arrows" }
-text{ key = "item.gust.1", value = "Zephyrine's Tempest" }
-text{ key = "item.armor_tools.1", value = "Armorer's Tool Set" }
-text{ key = "item.manna_oak_twig.1", value = "Manna Oak Twig" }
-text{ key = "item.manna_oak_letter.1", value = "Manna Oak Letter" }
-text{ key = "item.sword_of_the_sea_king.1", value = "Sword of the Sea King" }
 text{ key = "item.oceansheart_chart.1", value = "Isle of Storms Chart" }
+text{ key = "item.oranges_shipment.1", value = "Box of Oranges" }
+text{ key = "item.potion_burlyblade.1", value = "Burlyblade Potion" }
+text{ key = "item.potion_fleetseed.1", value = "Fleetseed Potion" }
+text{ key = "item.potion_magic_restoration.1", value = "Potion of Magic Restoration" }
+text{ key = "item.potion_stoneskin.1", value = "Stoneskin Potion" }
+text{ key = "item.prize_money.1", value = "Prize Money (200 Crowns)" }
+text{ key = "item.sleeping_draught.1", value = "Sleeping Draught" }
+text{ key = "item.spear.1", value = "Bear Warriors' Spear" }
+text{ key = "item.stone_beak.1", value = "A Beak-shaped Stone?" }
+text{ key = "item.sword_of_the_sea_king.1", value = "Sword of the Sea King" }
+text{ key = "item.thunder_charm.1", value = "Seabird's Tear" }
+text{ key = "item.whisky_for_juglan.1", value = "Whisky" }
+text{ key = "item.witch_hazel.1", value = "Witch Hazel Flowers" }
+text{ key = "item_desc.apples.2", value = "Apples (set of 3) - each heals two hearts" }
+text{ key = "item_desc.apples.4", value = "Apples (set of 10) - each heals two hearts" }
+text{ key = "item_desc.arrow.3", value = "Arrows (qty: 5)" }
+text{ key = "item_desc.arrow.5", value = "Arrows (qty: 20)" }
+text{ key = "item_desc.berries.3", value = "Berries (5 pack) - each heals half a heart" }
+text{ key = "item_desc.berries.4", value = "Berries (20 pack) - each heals half a heart" }
+text{ key = "item_desc.bomb.3", value = "Bombs (qty: 5)" }
+text{ key = "item_desc.bomb.4", value = "Bombs (qty: 10)" }
+text{ key = "item_desc.bread.2", value = "Burroak Bread (5 loaves)- each heals five hearts" }
+text{ key = "item_desc.bread.3", value = "Burroak Bread (10 loaves)- each heals five hearts" }
+text{ key = "item_desc.elixer.1", value = "Elixer - Recover all health, or revive you after KO" }
+text{ key = "item_desc.potion_burlyblade.1", value = "Burlyblade Potion - deal 1.5 damage for 4 minutes" }
+text{ key = "item_desc.potion_magic_restoration.1", value = "Magic Potion - Restores your magic power" }
+text{ key = "item_desc.potion_stoneskin.1", value = "Stoneskin Potion - Take half damage for 4 minutes" }
+text{ key = "item_desc.unattainable_collectable.1", value = "" }
 text{ key = "key1.false", value = "sub 1 is bad" }
 text{ key = "key1.true", value = "sub 1 is good" }
 text{ key = "key2.false", value = "I think so" }
@@ -91,6 +99,7 @@ text{ key = "location.goatshead_harbor", value = "Goatshead Harbor" }
 text{ key = "location.goatshead_island", value = "Goatshead Island" }
 text{ key = "location.gull_rock", value = "Gull Rock" }
 text{ key = "location.hourglass_fort", value = "Hourglass Fort" }
+text{ key = "location.isle_of_storms", value = "Isle of Storms" }
 text{ key = "location.ivystump", value = "Ivystump Village" }
 text{ key = "location.kingsdown_isle", value = "Kingsdown Isle" }
 text{ key = "location.lighthouse", value = "Crumbling Lighthouse" }
@@ -116,7 +125,6 @@ text{ key = "location.veilwood", value = "The Veilwood" }
 text{ key = "location.west_coast", value = "West Oak" }
 text{ key = "location.yarrowmouth", value = "Yarrowmouth" }
 text{ key = "location.yarrowmouth_village", value = "Yarrowmouth" }
-text{ key = "location.isle_of_storms", value = "Isle of Storms" }
 text{ key = "menu.quest_log.back_prompt", value = "D Back" }
 text{ key = "menu.quest_log.main_quests_tab", value = "Main\nQuests" }
 text{ key = "menu.quest_log.no_main_quests", value = "You have no main quests" }
@@ -126,4 +134,10 @@ text{ key = "menu.quest_log.quests_count", value = "$v1 of $v2 complete" }
 text{ key = "menu.quest_log.side_quests_tab", value = "Side\nQuests" }
 text{ key = "menu.quest_log.title", value = "Quest Log" }
 text{ key = "menu.quest_update.quest_updated", value = "Quest Log Updated!" }
+text{ key = "menu.shop.item_price", value = "Price: %2d crowns" }
+text{ key = "menu.title.cancel", value = "Cancel" }
+text{ key = "menu.title.confirm", value = "Confirm" }
+text{ key = "menu.title.continue", value = "Continue" }
+text{ key = "menu.title.new_game", value = "New Game" }
+text{ key = "menu.title.quit", value = "Quit" }
 text{ key = "player_name", value = "Tilia" }

--- a/data/languages/en/text/strings.dat
+++ b/data/languages/en/text/strings.dat
@@ -1,4 +1,9 @@
 text{ key = "action.back", value = "Back" }
+text{ key = "menu.title.continue", value = "Continue" }
+text{ key = "menu.title.new_game", value = "New Game" }
+text{ key = "menu.title.quit", value = "Quit" }
+text{ key = "menu.title.confirm", value = "Confirm" }
+text{ key = "menu.title.cancel", value = "Cancel" }
 text{ key = "item.elixer.1", value = "Elixer Vitae" }
 text{ key = "item.potion_magic_restoration.1", value = "Potion of Magic Restoration"}
 text{ key = "item.potion_stoneskin.1", value = "Stoneskin Potion"}

--- a/data/languages/en/text/strings.dat
+++ b/data/languages/en/text/strings.dat
@@ -7,6 +7,38 @@ text{ key = "item.potion_fleetseed.1", value = "Fleetseed Potion"}
 text{ key = "item.ether_bombs.1", value = "Ether Bombs"}
 text{ key = "item.iron_candle.1", value = "Salt Candles"}
 text{ key = "item.homing_eye.1", value = "Seeker Eyes"}
+text{ key = "item.bow.1", value = "Bow" }
+text{ key = "item.bombs_counter_2.1", value = "Bombs" }
+text{ key = "item.barrier.1", value = "Devana's Barrier" }
+text{ key = "item.ball_and_chain.1", value = "Flail" }
+text{ key = "item.boomerang.1", value = "Boomerang" }
+text{ key = "item.spear.1", value = "Bear Warriors' Spear" }
+text{ key = "item.bow_warp.1", value = "Warpbolt Charm" }
+text{ key = "item.bow_bombs.1", value = "Bomb Arrows" }
+text{ key = "item.bow_fire.1", value = "Flame Arrows" }
+text{ key = "item.berries.1", value = "Berries" }
+text{ key = "item.apples.1", value = "Apples" }
+text{ key = "item.bread.1", value = "Burroak Bread" }
+text{ key = "item.thunder_charm.1", value = "Seabird's Tear" }
+text{ key = "item.leaf_tornado.1", value = "Amalenchier's Wrath" }
+text{ key = "item.gust.1", value = "Zephyrine's Tempest" }
+text{ key = "item.crystal_spark.1", value = "Ophira's Ember" }
+text{ key = "item.cyclone_charm.1", value = "Cyclone Charm" }
+text{ key = "item.coral_ore.1", value = "Coral Ore" }
+text{ key = "item.burdock.1", value = "Burdock Roots" }
+text{ key = "item.chamomile.1", value = "Chamomile Flowers" }
+text{ key = "item.firethorn_berries.1", value = "Firethorn Berries" }
+text{ key = "item.ghost_orchid.1", value = "Ghost Orchids" }
+text{ key = "item.kingscrown.1", value = "Kingscrown Blooms" }
+text{ key = "item.lavendar.1", value = "Lavendar Flowers" }
+text{ key = "item.witch_hazel.1", value = "Witch Hazel Flowers" }
+text{ key = "item.mandrake_white.1", value = "White Mandrake Roots" }
+text{ key = "item.mandrake.1", value = "Mandrake Root" }
+text{ key = "item.geode.1", value = "Monsterous Geodes" }
+text{ key = "item.monster_bones.1", value = "Monster Bones" }
+text{ key = "item.monster_eye.1", value = "Monster Eye" }
+text{ key = "item.monster_guts.1", value = "Eyes of Monstrosity" }
+text{ key = "item.monster_heart.1", value = "Abyssal Hearts" }
 text{ key = "item.whisky_for_juglan.1", value = "Whisky" }
 text{ key = "item.iron_pinecone.1", value = "Iron Pinecone" }
 text{ key = "item.aster_note.1", value = "Threatening Note" }

--- a/data/languages/en/text/strings.dat
+++ b/data/languages/en/text/strings.dat
@@ -1,12 +1,41 @@
 text{ key = "action.back", value = "Back" }
-text{ key = "item.elixer", value = "Elixer Vitae"}
-text{ key = "item.potion_magic_restoration", value = "Potion of Magic Restoration"}
-text{ key = "item.potion_stoneskin", value = "Stoneskin Potion"}
-text{ key = "item.potion_burlyblade", value = "Burlyblade Potion"}
-text{ key = "item.potion_fleetseed", value = "Fleetseed Potion"}
-text{ key = "item.ether_bombs", value = "Ether Bombs"}
-text{ key = "item.iron_candle", value = "Salt Candles"}
-text{ key = "item.homing_eye", value = "Seeker Eyes"}
+text{ key = "item.elixer.1", value = "Elixer Vitae" }
+text{ key = "item.potion_magic_restoration.1", value = "Potion of Magic Restoration"}
+text{ key = "item.potion_stoneskin.1", value = "Stoneskin Potion"}
+text{ key = "item.potion_burlyblade.1", value = "Burlyblade Potion"}
+text{ key = "item.potion_fleetseed.1", value = "Fleetseed Potion"}
+text{ key = "item.ether_bombs.1", value = "Ether Bombs"}
+text{ key = "item.iron_candle.1", value = "Salt Candles"}
+text{ key = "item.homing_eye.1", value = "Seeker Eyes"}
+text{ key = "item.whisky_for_juglan.1", value = "Whisky" }
+text{ key = "item.iron_pinecone.1", value = "Iron Pinecone" }
+text{ key = "item.aster_note.1", value = "Threatening Note" }
+text{ key = "item.contract.1", value = "Exploitative Contract" }
+text{ key = "item.oranges_shipment.1", value = "Box of Oranges" }
+text{ key = "item.prize_money.1", value = "Prize Money (200 Crowns)" }
+text{ key = "item.key_thrush_fort.1", value = "Thrush Fort Key" }
+text{ key = "item.charts.1", value = "Klepton's Charts" }
+text{ key = "item.key_kingsdown.1", value = "Mallow's Key" }
+text{ key = "item.key_juniper_grove.1", value = "Juniper Grove Entrance Key" }
+text{ key = "item.key_juniper_grove_2.1", value = "Juniper Grove Inner Gate Key" }
+text{ key = "item.key_mushroom_spot.1", value = "Key to Mushroom Picking Spot" }
+text{ key = "item.key_mead_safehouse.1", value = "Sticky Honey Key" }
+text{ key = "item.key_juneberry_inn.1", value = "Key to Another Inn?" }
+text{ key = "item.key_poplar_shack.1", value = "Mossy Poplar Forest Key" }
+text{ key = "item.key_sinking_lighthouse.1", value = "Seaglint Ruins Key" }
+text{ key = "item.stone_beak.1", value = "A Beak-shaped Stone?" }
+text{ key = "item.sleeping_draught.1", value = "Sleeping Draught" }
+text{ key = "item.hideout_chart.1", value = "Pirate Council Hideout Chart" }
+text{ key = "item.monkshood.1", value = "Monkshood Petals" }
+text{ key = "item.honeycomb.1", value = "Hornet Honeycomb" }
+text{ key = "item.bomb_arrow_ticket.1", value = "Bomb Shop Ticket" }
+text{ key = "item.bow_bombs.1", value = "Bomb Arrows" }
+text{ key = "item.gust.1", value = "Zephyrine's Tempest" }
+text{ key = "item.armor_tools.1", value = "Armorer's Tool Set" }
+text{ key = "item.manna_oak_twig.1", value = "Manna Oak Twig" }
+text{ key = "item.manna_oak_letter.1", value = "Manna Oak Letter" }
+text{ key = "item.sword_of_the_sea_king.1", value = "Sword of the Sea King" }
+text{ key = "item.oceansheart_chart.1", value = "Isle of Storms Chart" }
 text{ key = "key1.false", value = "sub 1 is bad" }
 text{ key = "key1.true", value = "sub 1 is good" }
 text{ key = "key2.false", value = "I think so" }
@@ -51,36 +80,6 @@ text{ key = "location.west_coast", value = "West Oak" }
 text{ key = "location.yarrowmouth", value = "Yarrowmouth" }
 text{ key = "location.yarrowmouth_village", value = "Yarrowmouth" }
 text{ key = "location.isle_of_storms", value = "Isle of Storms" }
-text{ key = "item.whisky_for_juglan.1", value = "Whisky" }
-text{ key = "item.iron_pinecone.1", value = "Iron Pinecone" }
-text{ key = "item.aster_note.1", value = "Threatening Note" }
-text{ key = "item.contract.1", value = "Exploitative Contract" }
-text{ key = "item.oranges_shipment.1", value = "Box of Oranges" }
-text{ key = "item.prize_money.1", value = "Prize Money (200 Crowns)" }
-text{ key = "item.key_thrush_fort.1", value = "Thrush Fort Key" }
-text{ key = "item.charts.1", value = "Klepton's Charts" }
-text{ key = "item.key_kingsdown.1", value = "Mallow's Key" }
-text{ key = "item.key_juniper_grove.1", value = "Juniper Grove Entrance Key" }
-text{ key = "item.key_juniper_grove_2.1", value = "Juniper Grove Inner Gate Key" }
-text{ key = "item.key_mushroom_spot.1", value = "Key to Mushroom Picking Spot" }
-text{ key = "item.key_mead_safehouse.1", value = "Sticky Honey Key" }
-text{ key = "item.key_juneberry_inn.1", value = "Key to Another Inn?" }
-text{ key = "item.key_poplar_shack.1", value = "Mossy Poplar Forest Key" }
-text{ key = "item.key_sinking_lighthouse.1", value = "Seaglint Ruins Key" }
-text{ key = "item.stone_beak.1", value = "A Beak-shaped Stone?" }
-text{ key = "item.sleeping_draught.1", value = "Sleeping Draught" }
-text{ key = "item.elixer.1", value = "Elixer" }
-text{ key = "item.hideout_chart.1", value = "Pirate Council Hideout Chart" }
-text{ key = "item.monkshood.1", value = "Monkshood Petals" }
-text{ key = "item.honeycomb.1", value = "Hornet Honeycomb" }
-text{ key = "item.bomb_arrow_ticket.1", value = "Bomb Shop Ticket" }
-text{ key = "item.bow_bombs.1", value = "Bomb Arrows" }
-text{ key = "item.gust.1", value = "Zephyrine's Tempest" }
-text{ key = "item.armor_tools.1", value = "Armorer's Tool Set" }
-text{ key = "item.manna_oak_twig.1", value = "Manna Oak Twig" }
-text{ key = "item.manna_oak_letter.1", value = "Manna Oak Letter" }
-text{ key = "item.sword_of_the_sea_king.1", value = "Sword of the Sea King" }
-text{ key = "item.oceansheart_chart.1", value = "Isle of Storms Chart" }
 text{ key = "menu.quest_log.back_prompt", value = "D Back" }
 text{ key = "menu.quest_log.main_quests_tab", value = "Main\nQuests" }
 text{ key = "menu.quest_log.no_main_quests", value = "You have no main quests" }

--- a/data/languages/en/text/strings.dat
+++ b/data/languages/en/text/strings.dat
@@ -23,7 +23,8 @@ text{ key = "item.cyclone_charm.1", value = "Cyclone Charm" }
 text{ key = "item.elixer.1", value = "Elixer Vitae" }
 text{ key = "item.ether_bombs.1", value = "Ether Bombs" }
 text{ key = "item.firethorn_berries.1", value = "Firethorn Berries" }
-text{ key = "item.geode.1", value = "Monsterous Geodes" }
+text{ key = "item.forsythia.1", value = "Forsythia Flowers" }
+text{ key = "item.geode.1", value = "Monster Geodes" }
 text{ key = "item.ghost_orchid.1", value = "Ghost Orchids" }
 text{ key = "item.gust.1", value = "Zephyrine's Tempest" }
 text{ key = "item.hideout_chart.1", value = "Pirate Council Hideout Chart" }
@@ -48,9 +49,10 @@ text{ key = "item.mandrake_white.1", value = "White Mandrake Roots" }
 text{ key = "item.manna_oak_letter.1", value = "Manna Oak Letter" }
 text{ key = "item.manna_oak_twig.1", value = "Manna Oak Twig" }
 text{ key = "item.monkshood.1", value = "Monkshood Petals" }
-text{ key = "item.monster_bones.1", value = "Monster Bones" }
-text{ key = "item.monster_eye.1", value = "Monster Eye" }
-text{ key = "item.monster_guts.1", value = "Eyes of Monstrosity" }
+text{ key = "item.monster_bones.1", value = "Undead Bones" }
+text{ key = "item.monster_eye.1", value = "Evil Eyes" }
+text{ key = "item.monster_guts.1", value = "Monster Guts" }
+text{ key = "item.monster_horn.1", value = "Beast Horns" }
 text{ key = "item.monster_heart.1", value = "Abyssal Hearts" }
 text{ key = "item.oceansheart_chart.1", value = "Isle of Storms Chart" }
 text{ key = "item.oranges_shipment.1", value = "Box of Oranges" }
@@ -134,6 +136,7 @@ text{ key = "menu.quest_log.quests_count", value = "$v1 of $v2 complete" }
 text{ key = "menu.quest_log.side_quests_tab", value = "Side\nQuests" }
 text{ key = "menu.quest_log.title", value = "Quest Log" }
 text{ key = "menu.quest_update.quest_updated", value = "Quest Log Updated!" }
+text{ key = "menu.sell.item_price", value = "%d crowns" }
 text{ key = "menu.shop.item_price", value = "Price: %2d crowns" }
 text{ key = "menu.title.cancel", value = "Cancel" }
 text{ key = "menu.title.confirm", value = "Confirm" }

--- a/data/languages/en/text/strings_bak.dat
+++ b/data/languages/en/text/strings_bak.dat
@@ -1,0 +1,146 @@
+text{ key = "action.back", value = "Back" }
+text{ key = "menu.title.continue", value = "Continue" }
+text{ key = "menu.title.new_game", value = "New Game" }
+text{ key = "menu.title.quit", value = "Quit" }
+text{ key = "menu.title.confirm", value = "Confirm" }
+text{ key = "menu.title.cancel", value = "Cancel" }
+text{ key = "item.elixer.1", value = "Elixer Vitae" }
+text{ key = "item.potion_magic_restoration.1", value = "Potion of Magic Restoration"}
+text{ key = "item.potion_stoneskin.1", value = "Stoneskin Potion"}
+text{ key = "item.potion_burlyblade.1", value = "Burlyblade Potion"}
+text{ key = "item.potion_fleetseed.1", value = "Fleetseed Potion"}
+text{ key = "item.ether_bombs.1", value = "Ether Bombs"}
+text{ key = "item.iron_candle.1", value = "Salt Candles"}
+text{ key = "item.homing_eye.1", value = "Seeker Eyes"}
+text{ key = "item.bow.1", value = "Bow" }
+text{ key = "item.bombs_counter_2.1", value = "Bombs" }
+text{ key = "item.barrier.1", value = "Devana's Barrier" }
+text{ key = "item.ball_and_chain.1", value = "Flail" }
+text{ key = "item.boomerang.1", value = "Boomerang" }
+text{ key = "item.spear.1", value = "Bear Warriors' Spear" }
+text{ key = "item.bow_warp.1", value = "Warpbolt Charm" }
+text{ key = "item.bow_bombs.1", value = "Bomb Arrows" }
+text{ key = "item.bow_fire.1", value = "Flame Arrows" }
+text{ key = "item.berries.1", value = "Berries" }
+text{ key = "item.apples.1", value = "Apples" }
+text{ key = "item.bread.1", value = "Burroak Bread" }
+text{ key = "item.thunder_charm.1", value = "Seabird's Tear" }
+text{ key = "item.leaf_tornado.1", value = "Amalenchier's Wrath" }
+text{ key = "item.gust.1", value = "Zephyrine's Tempest" }
+text{ key = "item.crystal_spark.1", value = "Ophira's Ember" }
+text{ key = "item.cyclone_charm.1", value = "Cyclone Charm" }
+text{ key = "item.coral_ore.1", value = "Coral Ore" }
+text{ key = "item.burdock.1", value = "Burdock Roots" }
+text{ key = "item.chamomile.1", value = "Chamomile Flowers" }
+text{ key = "item.firethorn_berries.1", value = "Firethorn Berries" }
+text{ key = "item.ghost_orchid.1", value = "Ghost Orchids" }
+text{ key = "item.kingscrown.1", value = "Kingscrown Blooms" }
+text{ key = "item.lavendar.1", value = "Lavendar Flowers" }
+text{ key = "item.witch_hazel.1", value = "Witch Hazel Flowers" }
+text{ key = "item.mandrake_white.1", value = "White Mandrake Roots" }
+text{ key = "item.mandrake.1", value = "Mandrake Root" }
+text{ key = "item.geode.1", value = "Monsterous Geodes" }
+text{ key = "item.monster_bones.1", value = "Monster Bones" }
+text{ key = "item.monster_eye.1", value = "Monster Eye" }
+text{ key = "item.monster_guts.1", value = "Eyes of Monstrosity" }
+text{ key = "item.monster_heart.1", value = "Abyssal Hearts" }
+text{ key = "item.whisky_for_juglan.1", value = "Whisky" }
+text{ key = "item.iron_pinecone.1", value = "Iron Pinecone" }
+text{ key = "item.aster_note.1", value = "Threatening Note" }
+text{ key = "item.contract.1", value = "Exploitative Contract" }
+text{ key = "item.oranges_shipment.1", value = "Box of Oranges" }
+text{ key = "item.prize_money.1", value = "Prize Money (200 Crowns)" }
+text{ key = "item.key_thrush_fort.1", value = "Thrush Fort Key" }
+text{ key = "item.charts.1", value = "Klepton's Charts" }
+text{ key = "item.key_kingsdown.1", value = "Mallow's Key" }
+text{ key = "item.key_juniper_grove.1", value = "Juniper Grove Entrance Key" }
+text{ key = "item.key_juniper_grove_2.1", value = "Juniper Grove Inner Gate Key" }
+text{ key = "item.key_mushroom_spot.1", value = "Key to Mushroom Picking Spot" }
+text{ key = "item.key_mead_safehouse.1", value = "Sticky Honey Key" }
+text{ key = "item.key_juneberry_inn.1", value = "Key to Another Inn?" }
+text{ key = "item.key_poplar_shack.1", value = "Mossy Poplar Forest Key" }
+text{ key = "item.key_sinking_lighthouse.1", value = "Seaglint Ruins Key" }
+text{ key = "item.stone_beak.1", value = "A Beak-shaped Stone?" }
+text{ key = "item.sleeping_draught.1", value = "Sleeping Draught" }
+text{ key = "item.hideout_chart.1", value = "Pirate Council Hideout Chart" }
+text{ key = "item.monkshood.1", value = "Monkshood Petals" }
+text{ key = "item.honeycomb.1", value = "Hornet Honeycomb" }
+text{ key = "item.bomb_arrow_ticket.1", value = "Bomb Shop Ticket" }
+text{ key = "item.bow_bombs.1", value = "Bomb Arrows" }
+text{ key = "item.gust.1", value = "Zephyrine's Tempest" }
+text{ key = "item.armor_tools.1", value = "Armorer's Tool Set" }
+text{ key = "item.manna_oak_twig.1", value = "Manna Oak Twig" }
+text{ key = "item.manna_oak_letter.1", value = "Manna Oak Letter" }
+text{ key = "item.sword_of_the_sea_king.1", value = "Sword of the Sea King" }
+text{ key = "item.oceansheart_chart.1", value = "Isle of Storms Chart" }
+text{ key = "item.desc.berries.3", value = "Berries (5 pack) - each heals half a heart" }
+text{ key = "item.desc.apples.2", value = "Apples (set of 3) - each heals two hearts" }
+text{ key = "item.desc.bread.2", value = "Burroak Bread (5 loaves)- each heals five hearts" }
+text{ key = "item.desc.elixer.1", value = "Elixer - Recover all health, or revive you after KO" }
+text{ key = "item.desc.potion_magic_restoration.1", value = "Magic Potion - Restores your magic power" }
+text{ key = "item.desc.arrow.3", value = "Arrows (qty: 5)" }
+text{ key = "item.desc.bomb.3", value = "Bombs (qty: 5)" }
+text{ key = "item.desc.berries.4", value = "Berries (20 pack) - each heals half a heart" }
+text{ key = "item.desc.apples.4", value = "Apples (set of 10) - each heals two hearts" }
+text{ key = "item.desc.bread.3", value = "Burroak Bread (10 loaves)- each heals five hearts" }
+text{ key = "item.desc.potion_stoneskin.1", value = "Stoneskin Potion - Take half damage for 4 minutes" }
+text{ key = "item.desc.potion_burlyblade.1", value = "Burlyblade Potion - deal 1.5 damage for 4 minutes" }
+text{ key = "item.desc.arrow.5", value = "Arrows (qty: 20)" }
+text{ key = "item.desc.bomb.4", value = "Bombs (qty: 10)" }
+text{ key = "item.desc.unattainable_collectable.1", value = "" }
+--text{ key = "", value = "" }
+text{ key = "menu.shop.item_price", value = "Price: %2d crowns" }
+text{ key = "key1.false", value = "sub 1 is bad" }
+text{ key = "key1.true", value = "sub 1 is good" }
+text{ key = "key2.false", value = "I think so" }
+text{ key = "key2.true", value = "really?" }
+text{ key = "location.abyss", value = "The Abyss" }
+text{ key = "location.amalenchier_tomb", value = "Amalenchier's Tomb" }
+text{ key = "location.ballast_harbor", value = "Ballast Harbor" }
+text{ key = "location.bear_catacombs", value = "Bear Warriors' Catacombs" }
+text{ key = "location.council_building", value = "Pirate's Outpost" }
+text{ key = "location.crabhook_village", value = "Crabhook Village" }
+text{ key = "location.drowned_village", value = "The Drowned Village" }
+text{ key = "location.eastoak", value = "Fort Crow" }
+text{ key = "location.foothills", value = "The Puzzlewood" }
+text{ key = "location.ghost_ship", value = "Zephyrine's Salvation" }
+text{ key = "location.goatshead_harbor", value = "Goatshead Harbor" }
+text{ key = "location.goatshead_island", value = "Goatshead Island" }
+text{ key = "location.gull_rock", value = "Gull Rock" }
+text{ key = "location.hourglass_fort", value = "Hourglass Fort" }
+text{ key = "location.ivystump", value = "Ivystump Village" }
+text{ key = "location.kingsdown_isle", value = "Kingsdown Isle" }
+text{ key = "location.lighthouse", value = "Crumbling Lighthouse" }
+text{ key = "location.limestone_island", value = "Limestone Island" }
+text{ key = "location.limestone_present", value = "Limestone Island" }
+text{ key = "location.marblecliff", value = "Marblecliff Mountain" }
+text{ key = "location.naerreturn_bay", value = "Naerreturn Bay" }
+text{ key = "location.oakhaven", value = "Oakhaven" }
+text{ key = "location.poplar_coast", value = "Spruce Head" }
+text{ key = "location.poplar_forest", value = "Poplar Forest" }
+text{ key = "location.port", value = "Oakhaven Port" }
+text{ key = "location.shipwreck_chain", value = "Cemetery of the Waves" }
+text{ key = "location.silent_glade", value = "Silent Glade" }
+text{ key = "location.silent_glade_health", value = "Last Chieftan's Tomb" }
+text{ key = "location.smoldering_rock", value = "Smoldering Rock" }
+text{ key = "location.snapmast", value = "Snapmast Reef" }
+text{ key = "location.snapmast_landing", value = "Snapmast Reef" }
+text{ key = "location.spruce_head", value = "Spruce Head" }
+text{ key = "location.spruce_head_shrine", value = "Spruce Head Shrine" }
+text{ key = "location.sunken_palace", value = "The Old Summer Court" }
+text{ key = "location.tern_marsh", value = "Tern Marsh" }
+text{ key = "location.veilwood", value = "The Veilwood" }
+text{ key = "location.west_coast", value = "West Oak" }
+text{ key = "location.yarrowmouth", value = "Yarrowmouth" }
+text{ key = "location.yarrowmouth_village", value = "Yarrowmouth" }
+text{ key = "location.isle_of_storms", value = "Isle of Storms" }
+text{ key = "menu.quest_log.back_prompt", value = "D Back" }
+text{ key = "menu.quest_log.main_quests_tab", value = "Main\nQuests" }
+text{ key = "menu.quest_log.no_main_quests", value = "You have no main quests" }
+text{ key = "menu.quest_log.no_side_quests", value = "You have no side quests" }
+text{ key = "menu.quest_log.quest_log_update", value = "Quest Log Updated!" }
+text{ key = "menu.quest_log.quests_count", value = "$v1 of $v2 complete" }
+text{ key = "menu.quest_log.side_quests_tab", value = "Side\nQuests" }
+text{ key = "menu.quest_log.title", value = "Quest Log" }
+text{ key = "menu.quest_update.quest_updated", value = "Quest Log Updated!" }
+text{ key = "player_name", value = "Tilia" }

--- a/data/main.lua
+++ b/data/main.lua
@@ -3,23 +3,19 @@
 -- See the Lua API! http://www.solarus-games.org/doc/latest
 
 require("scripts/features")
-local title_screen = require"scripts/menus/title_screen"
-
+local initial_menus = require"scripts/menus/initial_menus"
 local game_manager = require("scripts/game_manager")
 
 -- This function is called when Solarus starts.
 function sol.main:on_started()
   --preload the sounds for faster access
   sol.audio.preload_sounds()
-  --set the language
-  sol.language.set_language("en")
 
   --Set the window title.
   sol.video.set_window_title("Ocean's Heart")
 
-  --Title Screen:
-  sol.menu.start(self, title_screen)
-
+  --Start initial menus:
+  initial_menus.start()
 end
 
 

--- a/data/scripts/menus/credits.lua
+++ b/data/scripts/menus/credits.lua
@@ -12,47 +12,44 @@ credits.bottom:set_opacity(0)
 credits.black = sol.surface.create()
 credits.black:fill_color{0,0,0}
 credits.black:set_opacity(0)
-
-local names = {
-{"Created By", "Max Mraz"},
-{"Additional Programming", "Llamazing"},
-{"Special Thanks to", "Alex Gleason"},
-{"The End",""}
-}
+credits.dialog_text = nil
 
 function credits:on_started()
-  credits:roll()
+  local dialog = sol.language.get_dialog("credits") --refresh each time menu starts in case language changed since last time
+  assert(dialog, "dialogs.dat entry 'credits' not found")
+  self.dialog_text = dialog.text:gsub("\r\n", "\n"):gsub("\r", "\n") --standardize line breaks
+  self:roll()
 end
+
+function credits:on_finished() self.dialog_text = nil end
 
 function credits:roll()
-  credits.black:fill_color{0,0,0}
-  credits.black:fade_in(150, function()
-    sol.timer.start(sol.main, 100, function()
-      credits:show_name(1)
+  self.black:fade_in(150, function()
+    sol.timer.start(self, 100, function()
+      self.next_text = self.dialog_text:gmatch("([^\n]*)\n") --each line including empty ones
+      self:show_next_name()
     end)
   end)
 end
 
-function credits:show_name(i)
-  credits.top:set_text(names[i][1])
-  credits.bottom:set_text(names[i][2])
-  credits.top:fade_in(100)
-  credits.bottom:fade_in(100, function()
-    sol.timer.start(sol.main, 1000, function()
-      credits.top:fade_out(40)
-      credits.bottom:fade_out(40, function()
-        credits:show_next_name(i+1)
+function credits:show_next_name()
+  local line = self.next_text()
+  if line then
+    local line1,line2 = line:match("([^%:]*)%:?([^%:]*)") --separate text at colon
+    self.top:set_text(line1)
+    self.bottom:set_text(line2)
+    self.top:fade_in(100)
+    self.bottom:fade_in(100, function()
+      sol.timer.start(self, 1000, function()
+        self.top:fade_out(40)
+        self.bottom:fade_out(40, function()
+          self:show_next_name()
+        end)
       end)
     end)
-  end)
-end
-
-function credits:show_next_name(i)
-  if i <= #names then
-    credits:show_name(i)
   else
     sol.timer.start(sol.main, 1000, function()
-      sol.menu.stop(require("scripts/menus/credits"))
+      sol.menu.stop(self)
       if sol.main:get_game() then
         sol.main.reset()
       else

--- a/data/scripts/menus/initial_menus.lua
+++ b/data/scripts/menus/initial_menus.lua
@@ -1,0 +1,127 @@
+--[[initial_menus.lua
+	version 1.0
+	28 Sep 2019
+	GNU General Public License Version 3
+	author: Llamazing
+
+	   __   __   __   __  _____   _____________  _______
+	  / /  / /  /  | /  |/  /  | /__   /_  _/  |/ / ___/
+	 / /__/ /__/ ^ |/ , ,  / ^ | ,:',:'_/ // /|  / /, /
+	/____/____/_/|_/_/|/|_/_/|_|_____/____/_/ |_/____/
+
+	This script manages the initial menus shown when launching the quest. Any active menus
+	are closed when a game is started, and the last initial menu should ensure that a game
+	is started before it is closed.
+
+	Usage:
+	local initial_menus = require"scripts/menus/initial_menu"
+	initial_menus.start(context, on_top)
+]]
+
+local multi_events = require"scripts/multi_events"
+
+--menus to show when starting game in this order
+--NOTE: the last menu is responsible for starting the game
+local MENU_LIST = {
+  "scripts/menus/language",
+  "scripts/menus/title_screen",
+}
+
+local initial_menus = {}
+
+local menus = {} --(table, array) list of initial menus
+local active_context --(various or nil) context to use for newly started initial menus
+local active_menu --(table, key/vale or nil) menu currently active or nil if none
+local active_on_top --(boolean or nil) whether newly started initial menus should be drawn on top of other menus
+
+--close any active initial menu when game starts
+local game_meta = sol.main.get_metatable"game"
+game_meta:register_event("on_started", function(self) initial_menus.stop() end)
+
+--// clear the variables related to the active menu
+local function reset()
+	active_menu = nil
+	active_context = nil
+	active_on_top = nil
+end
+
+--Initialize
+for i,menu_script in ipairs(MENU_LIST) do
+	--load initial menu scripts
+	local menu = require(menu_script)
+	table.insert(menus, menu)
+
+	--register menu with multi-events if not already
+	if not menu.register_event then multi_events:enable(menu) end
+
+	--start next menu whenever a menu is closed
+	menu:register_event("on_finished", function(self)
+		local next_menu = menus[i+1]
+		if active_menu and next_menu then --active_menu is nil if a game was started or initial_menus.stop() was called
+			active_menu = next_menu
+
+			--if there's an error in starting the next menu then need to set active_menu to nil
+			local is_success, err = pcall(function() sol.menu.start(active_context, next_menu, on_top) end)
+			if not is_success then
+				reset()
+				error(err)
+			end
+		else reset() end --now done
+	end)
+end
+
+--// Starts the first initial menu, can only be called if no initial menu is currently running
+	--context (various, optional) - context to use when starting the menu, see sol.menu.start() documentation
+		--default: sol.main
+	--on_top (boolean, optional) - whether the menu should be drawn on top of other menus
+		--default: false (drawn on bottom)
+function initial_menus.start(context, on_top)
+	assert(not active_menu, "Error in 'initial_menus': already started")
+	if #menus==0 then return end --do nothing if no initial menus defined
+	context = context or sol.main
+	on_top = on_top or false
+
+	local first_menu = menus[1]
+	active_context = context
+	active_menu = first_menu
+	active_on_top = on_top
+
+	--start the first initial menu, need to set active_menu to nil if there is an error in starting the menu
+	local is_success, err = pcall(function() sol.menu.start(context, first_menu, on_top) end)
+	if not is_success then
+		reset()
+		error(err)
+	end
+end
+
+--// Stops the active initial menu if one is currently active, otherwise does nothing
+function initial_menus.stop()
+	if active_menu then
+		reset() --reset before stopping active menu so next menu won't be started
+		sol.menu.stop(active_menu)
+	end
+end
+
+--// Returns the active initial menu (table, key/value) or nil if not running
+function initial_menus.active_menu() return active_menu end
+
+--// Starts the next initial menu if currently running, otherwise does nothing
+function initial_menus.next()
+	if active_menu then	sol.menu.stop(active_menu) end
+end
+
+return initial_menus
+
+--[[ Copyright 2019 Llamazing
+  []
+  [] This program is free software: you can redistribute it and/or modify it under the
+  [] terms of the GNU General Public License as published by the Free Software Foundation,
+  [] either version 3 of the License, or (at your option) any later version.
+  []
+  [] It is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+  [] without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+  [] PURPOSE.  See the GNU General Public License for more details.
+  []
+  [] You should have received a copy of the GNU General Public License along with this
+  [] program.  If not, see <http://www.gnu.org/licenses/>.
+  ]]

--- a/data/scripts/menus/inventory.lua
+++ b/data/scripts/menus/inventory.lua
@@ -5,35 +5,35 @@ multi_events:enable(inventory)
 
 --All items that could ever show up in the inventory:
 local all_equipment_items = {
-    {item = "bow", name = "Bow", assignable = true,},
-    {item = "bombs_counter_2", name = "Bombs", assignable = true,},
-    {item = "barrier", name = "Devana's Barrier", assignable = true,},
-    {item = "ball_and_chain", name = "Flail", assignable = true},
-    {item = "boomerang", name = "Boomerang", assignable = true,},
-    {item = "spear", name = "Bear Warriors' Spear", assignable = true,},
-    {item = "bow_warp", name = "Warpbolt Charm", assignable = true,},
-    {item = "bow_bombs", name = "Bomb Arrows", assignable = true,},
-    {item = "bow_fire", name = "Flame Arrows", assignable = true,},
-    {item = "iron_candle", name = "Salt Candles", assignable = true},
-    {item = "ether_bombs", name = "Ether Bombs", assignable = true},
-    {item = "homing_eye", name = "Seeker Eyes", assignable = true},
-    {item = "berries", name = "Berries", assignable = false,},
-    {item = "apples", name = "Apples", assignable = false,},
-    {item = "bread", name = "Burroak Bread", assignable = false,},
-    {item = "elixer", name = "Elixer Vitae", assignable = false,},
-    {item = "thunder_charm", name = "Seabird's Tear", assignable = true,},
-    {item = "leaf_tornado", name = "Amalenchier's Wrath", assignable = true,},
-    {item = "potion_magic_restoration", name = "Magic Restoring Potion", assignable = false,},
-    {item = "potion_stoneskin", name = "Stoneskin Potion", assignable = false,},
-    {item = "potion_burlyblade", name = "Burlyblade Potion", assignable = false,},
-    {item = "potion_fleetseed", name = "Fleetseed Potion", assignable = false,},
-    {item = "gust", name = "Zephyrine's Tempest", assignable = true,},
-    {item = "crystal_spark", name = "Ophira's Ember", assignable = true,},
---    {item = "cyclone_charm", name = "Cyclone Charm", assignable = true,},
---    {item = "unattainable_collectable", name = "", assignable = false},
---    {item = "unattainable_collectable", name = "", assignable = false},
---    {item = "unattainable_collectable", name = "", assignable = false},
---    {item = "unattainable_collectable", name = "", assignable = false},
+    {item = "bow", assignable = true,},
+    {item = "bombs_counter_2", assignable = true,},
+    {item = "barrier", assignable = true,},
+    {item = "ball_and_chain", assignable = true},
+    {item = "boomerang", assignable = true,},
+    {item = "spear", assignable = true,},
+    {item = "bow_warp", assignable = true,},
+    {item = "bow_bombs", assignable = true,},
+    {item = "bow_fire", assignable = true,},
+    {item = "iron_candle", assignable = true},
+    {item = "ether_bombs", assignable = true},
+    {item = "homing_eye", assignable = true},
+    {item = "berries", assignable = false,},
+    {item = "apples", assignable = false,},
+    {item = "bread", assignable = false,},
+    {item = "elixer", assignable = false,},
+    {item = "thunder_charm", assignable = true,},
+    {item = "leaf_tornado", assignable = true,},
+    {item = "potion_magic_restoration", assignable = false,},
+    {item = "potion_stoneskin", assignable = false,},
+    {item = "potion_burlyblade", assignable = false,},
+    {item = "potion_fleetseed", assignable = false,},
+    {item = "gust", assignable = true,},
+    {item = "crystal_spark", assignable = true,},
+--    {item = "cyclone_charm", assignable = true,},
+--    {item = "unattainable_collectable", assignable = false},
+--    {item = "unattainable_collectable", assignable = false},
+--    {item = "unattainable_collectable", assignable = false},
+--    {item = "unattainable_collectable", assignable = false},
 }
 
 --All collectable items
@@ -212,10 +212,13 @@ end
 
 function inventory:update_description_panel()
     --update description panel
-    if self:get_item_at_current_index() and self.description_panel then
-        self.description_panel:set_text(all_equipment_items[cursor_index + 1].name)
-    elseif self.description_panel then
-        self.description_panel:set_text("")
+    if self.description_panel then
+        local item = self:get_item_at_current_index()
+        if item then
+          local item_desc = sol.language.get_string("item."..item:get_name()..".1") or ""
+          self.description_panel:set_text(item_desc)
+        else self.description_panel:set_text("")
+        end
     end
 end
 

--- a/data/scripts/menus/language.lua
+++ b/data/scripts/menus/language.lua
@@ -1,0 +1,14 @@
+--Language selection screen at start of game
+--current behavior simply sets language to english
+
+local menu = {}
+
+function menu:on_started()
+	if sol.language.get_language() then sol.menu.stop(self) end --language already set, skip this screen
+	sol.language.set_language("en")
+
+	--TODO allow player to select language
+	sol.menu.stop(self)
+end
+
+return menu

--- a/data/scripts/menus/quest_update_icon.lua
+++ b/data/scripts/menus/quest_update_icon.lua
@@ -6,9 +6,14 @@ local text_surface = sol.text_surface.create({
   vertical_alignment = "top",
   horizontal_alignment = "left",
 })
+local text_key = "menu.quest_update.quest_updated"
 
-text_surface:set_text("Quest Log Updated!")
-
+function quest_update_icon:on_started()
+  --have to wait until after initial menus to get text from strings.dat
+  local update_text = sol.language.get_string(text_key)
+  assert(update_text, "Strings.dat key not found: "..text_key)
+  text_surface:set_text(update_text)
+end
 
 function quest_update_icon:on_draw(dst_surface)
   text_surface:draw(dst_surface, 300, 5)

--- a/data/scripts/menus/title_screen.lua
+++ b/data/scripts/menus/title_screen.lua
@@ -68,12 +68,12 @@ function title_screen:on_started()
     return math.random(8000, 9000)
   end)
 
-  text_surface:set_text("  Continue")
-  text_surface:draw(selection_surface, 0, 0)
-  text_surface2:set_text("  New Game")
-  text_surface2:draw(selection_surface, 0, 16)
-  text_surface3:set_text("  Quit")
-  text_surface3:draw(selection_surface, 0, 32)
+  text_surface:set_text_key("menu.title.continue")
+  text_surface:draw(selection_surface, 12, 0)
+  text_surface2:set_text_key("menu.title.new_game")
+  text_surface2:draw(selection_surface, 12, 16)
+  text_surface3:set_text_key("menu.title.quit")
+  text_surface3:draw(selection_surface, 12, 32)
 
 
   sol.timer.start(title_screen, math.random(1000, 2000), function()
@@ -146,10 +146,10 @@ function title_screen:on_key_pressed(command)
       sol.audio.play_sound("danger")
       confirming = true
       selection_surface:clear()
-      text_surface:set_text("  Confirm")
-      text_surface:draw(selection_surface, 0, 0)
-      text_surface2:set_text("  Cancel")
-      text_surface2:draw(selection_surface, 0, 16)
+      text_surface:set_text_key("menu.title.confirm")
+      text_surface:draw(selection_surface, 12, 0)
+      text_surface2:set_text_key("menu.title.cancel")
+      text_surface2:draw(selection_surface, 12, 16)
 
     --New Game state, confirm new game
     elseif cursor_index == 0 and confirming then
@@ -163,12 +163,12 @@ function title_screen:on_key_pressed(command)
       sol.audio.play_sound("no")
       confirming = false
       selection_surface:clear()
-      text_surface:set_text("  Continue")
-      text_surface:draw(selection_surface, 0, 0)
-      text_surface2:set_text("  New Game")
-      text_surface2:draw(selection_surface, 0, 16)
-      text_surface3:set_text("  Quit")
-      text_surface3:draw(selection_surface, 0, 32)
+      text_surface:set_text_key("menu.title.continue")
+      text_surface:draw(selection_surface, 12, 0)
+      text_surface2:set_text_key("menu.title.new_game")
+      text_surface2:draw(selection_surface, 12, 16)
+      text_surface3:set_text_key("menu.title.quit")
+      text_surface3:draw(selection_surface, 12, 32)
 
     elseif  cursor_index == 2 then
       sol.main.exit()

--- a/data/scripts/shops/crafting.lua
+++ b/data/scripts/shops/crafting.lua
@@ -101,7 +101,7 @@ function crafting_menu:update_recipes()
     local recipe_surface = sol.text_surface.create{
       vertical_alignment="top",
       font="oceansfont",
-      text_key="item."..unlocked_recipes[i].item_name
+      text_key="item."..unlocked_recipes[i].item_name..".1" --all crafting ingredients are variant 1
     }
     if not crafting_menu:can_make_recipe(unlocked_recipes[i]) then
       recipe_surface:set_color_modulation{150,150,150,200}

--- a/data/scripts/shops/sell_menu.lua
+++ b/data/scripts/shops/sell_menu.lua
@@ -5,22 +5,22 @@ multi_events:enable(inventory)
 
 --All items that you could sell:
 local all_items = {
-    {item = "burdock", name = "Burdock Root", price = 5},
-    {item = "chamomile", name = "Chamomile", price = 5},
-    {item = "firethorn_berries", name = "Firethorn", price = 5},
-    {item = "forsythia", name = "Forsythia Petals", price = 5},
-    {item = "ghost_orchid", name = "Ghost Orchid", price = 35},
-    {item = "kingscrown", name = "Kingscrown", price = 25},
-    {item = "lavendar", name = "Lavendar", price = 5},
-    {item = "witch_hazel", name = "Witch Hazel", price = 10},
-    {item = "mandrake", name = "Mandrake Root", price = 15},
-    {item = "mandrake_white", name = "White Mandrake Root", price = 40},
-    {item = "geode", name = "Monster Geode", price = 10},
-    {item = "monster_bones", name = "Undead Bones", price = 10},
-    {item = "monster_guts", name = "Monster Guts", price = 5},
-    {item = "monster_eye", name = "Evil Eye", price = 35},
-    {item = "monster_horn", name = "Beast Horn", price = 30},
-    {item = "monster_heart", name = "Abyssal Heart", price = 100},
+    {item = "burdock", price = 5},
+    {item = "chamomile", price = 5},
+    {item = "firethorn_berries", price = 5},
+    {item = "forsythia", price = 5},
+    {item = "ghost_orchid", price = 35},
+    {item = "kingscrown", price = 25},
+    {item = "lavendar", price = 5},
+    {item = "witch_hazel", price = 10},
+    {item = "mandrake", price = 15},
+    {item = "mandrake_white", price = 40},
+    {item = "geode", price = 10},
+    {item = "monster_bones", price = 10},
+    {item = "monster_guts", price = 5},
+    {item = "monster_eye", price = 35},
+    {item = "monster_horn", price = 30},
+    {item = "monster_heart", price = 100},
 }
 
 --constants:
@@ -37,13 +37,13 @@ local cursor_index
 --// Gets/sets the x,y position of the menu in pixels
 function inventory:get_xy() return self.x, self.y end
 function inventory:set_xy(x, y)
-	x = tonumber(x)
-	assert(x, "Bad argument #2 to 'set_xy' (number expected)")
-	y = tonumber(y)
-	assert(y, "Bad argument #3 to 'set_xy' (number expected)")
+    x = tonumber(x)
+    assert(x, "Bad argument #2 to 'set_xy' (number expected)")
+    y = tonumber(y)
+    assert(y, "Bad argument #3 to 'set_xy' (number expected)")
 
-	self.x = math.floor(x)
-	self.y = math.floor(y)
+    self.x = math.floor(x)
+    self.y = math.floor(y)
 end
 
 
@@ -140,10 +140,13 @@ end
 function inventory:update_description_panel()
     --update description panel
     local game = sol.main.get_game()
+    local item_info = all_items[cursor_index + 1]
     if self:get_item_at_current_index() and self.description_panel
-    and game:has_item(all_items[cursor_index+1].item) then
-        self.description_panel:set_text(all_items[cursor_index + 1].name)
-        self.price_panel:set_text(all_items[cursor_index + 1].price .. " crowns")
+    and game:has_item(item_info.item) then
+        self.description_panel:set_text_key("item."..item_info.item..".1")
+        local price_string = sol.language.get_string("menu.sell.item_price")
+        assert(price_string, "Error: strings.dat entry 'menu.sell.item_price' not found")
+        self.price_panel:set_text(price_string:format(item_info.price))
     elseif self.description_panel then
         self.description_panel:set_text("")
         self.price_panel:set_text(" ")

--- a/data/scripts/shops/shop_menu.lua
+++ b/data/scripts/shops/shop_menu.lua
@@ -5,50 +5,36 @@ multi_events:enable(inventory)
 
 --All items that could ever show up in the shop:
 local all_items = {
-    {item = "berries", name = "Berries", price = 5, variant = 3,
-      availability_variable = "available_in_shop_berries",
-      description = "Berries (5 pack) - each heals half a heart"},
-    {item = "apples", name = "Apples", price = 12, variant = 2,
-      availability_variable = "available_in_shop_apples",
-      description = "Apples (set of 3) - each heals two hearts"},
-    {item = "bread", name = "Burroak Bread", price = 45, variant = 2,
-      availability_variable = "available_in_shop_bread",
-      description = "Burroak Bread (5 loaves)- each heals five hearts"},
-    {item = "elixer", name = "Elixer Vitae", price = 70, variant = 1,
-      availability_variable = "available_in_shop_elixer",
-      description = "Elixer - Recover all health, or revive you after KO"},
-    {item = "potion_magic_restoration", name = "Magic Restoring Portion", price = 50, variant = 1,
-      availability_variable = "available_in_shop_magic_restoring_potion",
-      description = "Magic Potion - Restores your magic power"},
-    {item = "unattainable_collectable", name="",price=0,variant=1,availability_variable="nil",description=""},
-    {item = "arrow", name = "Arrows", price = 10, variant = 3,
-      availability_variable = "available_in_shop_arrows",
-      description = "Arrows (qty: 5)"},
-    {item = "bomb", name = "Bombs", price = 30, variant = 3,
-      availability_variable = "available_in_shop_bombs",
-      description = "Bombs (qty: 5)"},
-    {item = "berries", name = "Berries", price = 20, variant = 4,
-      availability_variable = "available_in_shop_berries",
-      description = "Berries (20 pack) - each heals half a heart"},
-    {item = "apples", name = "Apples", price = 40, variant = 4,
-      availability_variable = "available_in_shop_apples",
-      description = "Apples (set of 10) - each heals two hearts"},
-    {item = "bread", name = "Burroak Bread", price = 90, variant = 3,
-      availability_variable = "available_in_shop_bread",
-      description = "Burroak Bread (10 loaves)- each heals five hearts"},
-    {item = "potion_stoneskin", name = "Stoneskin Potion", price = 80, variant = 1,
-      availability_variable = "available_in_shop_stoneskin_potion",
-      description = "Stoneskin Potion - Take half damage for 4 minutes",},
-    {item = "potion_burlyblade", name = "Burlyblade Potion", price = 80, variant = 1,
-      availability_variable = "available_in_shop_burlyblade_potion",
-      description = "Burlyblade Potion - deal 1.5 damage for 4 minutes",},
-    {item = "unattainable_collectable", name="",price=0,variant=1,availability_variable="nil",description=""},
-    {item = "arrow", name = "Arrows", price = 40, variant = 5,
-      availability_variable = "available_in_shop_arrows",
-      description = "Arrows (qty: 20)"},
-    {item = "bomb", name = "Bombs", price = 60, variant = 4,
-      availability_variable = "available_in_shop_bombs",
-      description = "Bombs (qty: 10)"},
+    {item = "berries", price = 5, variant = 3,
+      availability_variable = "available_in_shop_berries"},
+    {item = "apples", price = 12, variant = 2,
+      availability_variable = "available_in_shop_apples"},
+    {item = "bread", price = 45, variant = 2,
+      availability_variable = "available_in_shop_bread"},
+    {item = "elixer", price = 70, variant = 1,
+      availability_variable = "available_in_shop_elixer"},
+    {item = "potion_magic_restoration", price = 50, variant = 1,
+      availability_variable = "available_in_shop_magic_restoring_potion"},
+    {item = "unattainable_collectable",price=0,variant=1,availability_variable="nil"},
+    {item = "arrow", price = 10, variant = 3,
+      availability_variable = "available_in_shop_arrows"},
+    {item = "bomb", price = 30, variant = 3,
+      availability_variable = "available_in_shop_bombs"},
+    {item = "berries", price = 20, variant = 4,
+      availability_variable = "available_in_shop_berries"},
+    {item = "apples", price = 40, variant = 4,
+      availability_variable = "available_in_shop_apples"},
+    {item = "bread", price = 90, variant = 3,
+      availability_variable = "available_in_shop_bread"},
+    {item = "potion_stoneskin", price = 80, variant = 1,
+      availability_variable = "available_in_shop_stoneskin_potion"},
+    {item = "potion_burlyblade", price = 80, variant = 1,
+      availability_variable = "available_in_shop_burlyblade_potion"},
+    {item = "unattainable_collectable",price=0,variant=1,availability_variable="nil"},
+    {item = "arrow", price = 40, variant = 5,
+      availability_variable = "available_in_shop_arrows"},
+    {item = "bomb", price = 60, variant = 4,
+      availability_variable = "available_in_shop_bombs"},
 }
 
 --constants:
@@ -65,13 +51,13 @@ local cursor_index
 --// Gets/sets the x,y position of the menu in pixels
 function inventory:get_xy() return self.x, self.y end
 function inventory:set_xy(x, y)
-	x = tonumber(x)
-	assert(x, "Bad argument #2 to 'set_xy' (number expected)")
-	y = tonumber(y)
-	assert(y, "Bad argument #3 to 'set_xy' (number expected)")
+    x = tonumber(x)
+    assert(x, "Bad argument #2 to 'set_xy' (number expected)")
+    y = tonumber(y)
+    assert(y, "Bad argument #3 to 'set_xy' (number expected)")
 
-	self.x = math.floor(x)
-	self.y = math.floor(y)
+    self.x = math.floor(x)
+    self.y = math.floor(y)
 end
 
 
@@ -170,10 +156,14 @@ end
 function inventory:update_description_panel()
     --update description panel
     local game = sol.main.get_game()
+    local item_info = all_items[cursor_index+1]
     if self:get_item_at_current_index() and self.description_panel
-    and game:get_value(all_items[cursor_index+1].availability_variable) then
-        self.description_panel:set_text(all_items[cursor_index + 1].description)
-        self.price_panel:set_text("Price: " .. all_items[cursor_index + 1].price .. " crowns")
+    and game:get_value(item_info.availability_variable) then
+        local desc_key = "item_desc.%s.%d" --key to lookup in strings.dat for item description
+        self.description_panel:set_text_key(desc_key:format(item_info.item, item_info.variant))
+        local price_string = sol.language.get_string("menu.shop.item_price")
+        assert(price_string, "Error: strings.dat entry 'menu.shop.item_price' not found")
+        self.price_panel:set_text(price_string:format(item_info.price))
     elseif self.description_panel then
         self.description_panel:set_text("")
         self.price_panel:set_text(" ")
@@ -214,7 +204,7 @@ function inventory:on_command_pressed(command)
               local current_item = all_items[cursor_index + 1]
               local current_amount
               local max_amount
-              if current_item.name == "Arrows" then
+              if current_item.item == "arrow" then
                 current_amount = game:get_item("bow"):get_amount()
                 max_amount = game:get_item("bow"):get_max_amount()
               else

--- a/data/scripts/shops/shop_menu.lua
+++ b/data/scripts/shops/shop_menu.lua
@@ -156,7 +156,7 @@ end
 function inventory:update_description_panel()
     --update description panel
     local game = sol.main.get_game()
-    local item_info = all_items[cursor_index+1]
+    local item_info = all_items[cursor_index + 1]
     if self:get_item_at_current_index() and self.description_panel
     and game:get_value(item_info.availability_variable) then
         local desc_key = "item_desc.%s.%d" --key to lookup in strings.dat for item description


### PR DESCRIPTION
Move text to strings.dat and dialogs.dat for localization support in the following menus:

- shops/crafting.lua
- menus/inventory.lua
- menus/quest_update_icon.lua
- menus/title_screen.lua
- shops/shop_menu.lua
- shops/sell_menu.lua
- menus/credits.lua

Does not address text that appears as images in these menus.