### PR TITLE
fix for multi-line strings.dat entries

### DIFF
--- a/data/languages/en/text/strings.dat
+++ b/data/languages/en/text/strings.dat
@@ -152,12 +152,12 @@ text{ key = "location.yarrowmouth_village", value = "Yarrowmouth Village" }
 text{ key = "location.zephyr_bay", value = "Zephyr Bay" }
 text{ key = "menu.potion_expired", value = "Potion effect expired" }
 text{ key = "menu.quest_log.back_prompt", value = "D: Back" }
-text{ key = "menu.quest_log.main_quests_tab", value = "Main\nQuests" }
+text{ key = "menu.quest_log.main_quests_tab", value = "Main\\nQuests" }
 text{ key = "menu.quest_log.no_main_quests", value = "You have no main quests" }
 text{ key = "menu.quest_log.no_side_quests", value = "You have no side quests" }
 text{ key = "menu.quest_log.quest_log_update", value = "Quest Log Updated!" }
 text{ key = "menu.quest_log.quests_count", value = "$v1 of $v2 complete" }
-text{ key = "menu.quest_log.side_quests_tab", value = "Side\nQuests" }
+text{ key = "menu.quest_log.side_quests_tab", value = "Side\\nQuests" }
 text{ key = "menu.quest_log.title", value = "Quest Log" }
 text{ key = "menu.quest_update.quest_updated", value = "Quest Log Updated!" }
 text{ key = "menu.sell.item_price", value = "%d crowns" }

--- a/data/scripts/menus/ui/array.lua
+++ b/data/scripts/menus/ui/array.lua
@@ -1,6 +1,6 @@
 --[[ array.lua
-	version 1.0
-	15 Dec 2018
+	version 1.0.1
+	22 Mar 2020
 	GNU General Public License Version 3
 	author: Llamazing
 
@@ -158,6 +158,7 @@ function control.create(properties, width, height)
 		assert(lang_code, "Language has not been set")
 		
 		local text = sol.language.get_string(key)
+		text = text:gsub("\\n", "\n") --silly workaround for Solarus issue #468
 		assert(text, "strings.dat key '"..key.."' not found for language: "..lang_code)
 		
 		self:set_text(text)
@@ -271,7 +272,7 @@ end
 
 return control
 
---[[ Copyright 2016-2018 Llamazing
+--[[ Copyright 2016-2020 Llamazing
   [] 
   [] This program is free software: you can redistribute it and/or modify it under the
   [] terms of the GNU General Public License as published by the Free Software Foundation,


### PR DESCRIPTION
strings.dat will no longer break when opened in the quest editor